### PR TITLE
Support nagios plugin mode

### DIFF
--- a/manifests/monitored_cron.pp
+++ b/manifests/monitored_cron.pp
@@ -9,7 +9,8 @@ define periodicnoise::monitored_cron (
   $month                     = undef,
   $max_execution_start_delay = undef,
   $execution_timeout,
-  $notification_interval     = undef
+  $notification_interval     = undef,
+  $wrap_nagios_plugin        = undef
 ) {
   $event = $name
 
@@ -27,7 +28,8 @@ define periodicnoise::monitored_cron (
     max_execution_start_delay => $max_execution_start_delay ? { undef => $periodicnoise::params::pn_max_execution_start_delay, default => $max_execution_start_delay },
     execution_timeout         => $execution_timeout,
     use_syslog                => $periodicnoise::params::pn_use_syslog,
-    event                     => $event
+    event                     => $event,
+    wrap_nagios_plugin        => $wrap_nagios_plugin ? { undef => $periodicnoise::params::pn_wrap_nagios_plugin, default => $wrap_nagios_plugin },
   }
 
   @@nagios_service { "$event on $periodicnoise::params::nagios_hostname":

--- a/spec/defines/monitored_cron_spec.rb
+++ b/spec/defines/monitored_cron_spec.rb
@@ -54,4 +54,20 @@ describe 'periodicnoise::monitored_cron', :type => :define do
       should contain_periodicnoise__cron('some_monitored_cron')
     end
   end
+
+  context 'as Nagios plugin wrapper' do
+    let (:title) { 'check_foo' }
+    let (:params) {{
+      :command               => 'check_foo',
+      :hour                  => 0,
+      :minute                => 0,
+      :execution_timeout     => '6h',
+      :wrap_nagios_plugin    => true,
+    }}
+
+    it 'should create a periodicnoise cron job' do
+      should contain_periodicnoise__cron('check_foo') \
+        .with_wrap_nagios_plugin(true)
+    end
+  end
 end


### PR DESCRIPTION
As a devop I would like to support nagios plugins like check_foo
in order to combine periodicnoise with passive monitoring events.

@mlafeldt @Luzifer Please take a look.
