### PR TITLE
Finish implementation of periodicnoise::once

### DIFF
--- a/manifests/once.pp
+++ b/manifests/once.pp
@@ -29,8 +29,15 @@ define periodicnoise::once (
   $_wrap_nagios_plugin        = $wrap_nagios_plugin ? { undef => $periodicnoise::params::pn_wrap_nagios_plugin, default => $wrap_nagios_plugin }
 
   exec { $name:
-    command   => template('periodicnoise/command.erb'),
-    user      => $user ? { undef => $periodicnoise::params::cron_user, default => $user },
-    require   => Package['periodicnoise']
+    command     => template('periodicnoise/command.erb'),
+    user        => $user ? { undef                        => $periodicnoise::params::cron_user, default => $user },
+    creates     => $creates,
+    onlyif      => $onlyif,
+    refresh     => $refresh,
+    refreshonly => $refreshonly,
+    tries       => $tries,
+    try_sleep   => $try_sleep,
+    unless      => $unless,
+    require     => Package['periodicnoise']
   }
 }

--- a/spec/defines/once_spec.rb
+++ b/spec/defines/once_spec.rb
@@ -138,4 +138,31 @@ describe 'periodicnoise::once', :type => :define do
     end
   end
 
+  context "with all exec specific parameters enabled" do
+    let (:params) {{
+      :command           => 'some_once_command',
+      :user              => 'root',
+      :execution_timeout => '10m',
+      :creates           => '/some/file',
+      :onlyif            => true,
+      :refresh           => true,
+      :refreshonly       => true,
+      :tries             => 1,
+      :try_sleep         => 0,
+      :unless            => true,
+    }}
+    it "should create a oncejob" do
+      should contain_exec('some_oncejob') \
+        .with_command('pn --timeout=10m --use-syslog -- some_once_command') \
+        .with_user('root') \
+        .with_creates('/some/file') \
+        .with_onlyif(true) \
+        .with_refresh(true) \
+        .with_refreshonly(true) \
+        .with_tries(1) \
+        .with_try_sleep(0) \
+        .with_unless(true) \
+        .with_require('Package[periodicnoise]')
+    end
+  end
 end


### PR DESCRIPTION
This implements all the nice and useful options of puppet's exec by passing them on.

Please note, that the features implemented by periodicnoise itself are intentionally left out.

@zined or @Bonko Please take a look
