### PR TITLE
use printf to avoid bashism

### DIFF
--- a/templates/nsca.erb
+++ b/templates/nsca.erb
@@ -1,5 +1,5 @@
 [monitoring]
-OK       = echo -e "<%= send_as_host -%>;%(event);0;%(message)\n" |/usr/sbin/send_nsca -H <%= send_to_host -%> -d ";"
-WARNING  = echo -e "<%= send_as_host -%>;%(event);1;%(message)\n" |/usr/sbin/send_nsca -H <%= send_to_host -%> -d ";"
-CRITICAL = echo -e "<%= send_as_host -%>;%(event);2;%(message)\n" |/usr/sbin/send_nsca -H <%= send_to_host -%> -d ";"
-UNKNOWN  = echo -e "<%= send_as_host -%>;%(event);3;%(message)\n" |/usr/sbin/send_nsca -H <%= send_to_host -%> -d ";"
+OK       = printf "<%= send_as_host -%>;%(event);0;%(message)\n" |/usr/sbin/send_nsca -H <%= send_to_host -%> -d ";"
+WARNING  = printf "<%= send_as_host -%>;%(event);1;%(message)\n" |/usr/sbin/send_nsca -H <%= send_to_host -%> -d ";"
+CRITICAL = printf "<%= send_as_host -%>;%(event);2;%(message)\n" |/usr/sbin/send_nsca -H <%= send_to_host -%> -d ";"
+UNKNOWN  = printf "<%= send_as_host -%>;%(event);3;%(message)\n" |/usr/sbin/send_nsca -H <%= send_to_host -%> -d ";"


### PR DESCRIPTION
in order to leverage the escaping fixes of recent periodicnoise and
avoid an bashism (echo -e) let's use the more portable printf

@mlafeldt PTAL
@zined thanks for the bug report!
