### PR TITLE
make it possible to configure servicegroups in nagios service

### DIFF
--- a/manifests/monitored_cron.pp
+++ b/manifests/monitored_cron.pp
@@ -16,7 +16,8 @@ define periodicnoise::monitored_cron (
   $nagios_check_freshness       = undef,
   $nagios_check_command         = undef,
   $nagios_max_check_attempts    = undef,
-  $nagios_contact_groups        = undef
+  $nagios_contact_groups        = undef,
+  $nagios_servicegroups         = undef,
 ) {
   $event = $name
 
@@ -52,6 +53,7 @@ define periodicnoise::monitored_cron (
       notes_url                   => $nagios_notes_url ? { undef => $periodicnoise::params::nagios_notes_url, default => $nagios_notes_url },
       check_freshness             => $nagios_check_freshness ? { undef => $periodicnoise::params::nagios_check_freshness, default => $nagios_check_freshness },
       freshness_threshold         => $nagios_freshness_threshold ? { undef => $periodicnoise::params::nagios_freshness_threshold, default => $nagios_freshness_threshold },
+      servicegroups               => $nagios_servicegroups ? { undef => $periodicnoise::params::nagios_servicegroups, default => $nagios_servicegroups },
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class periodicnoise::params (
   $nagios_contact_groups        = undef,
   $nagios_notes_url             = undef,
   $nagios_freshness_threshold   = undef,
-  $nagios_check_freshness       = undef
+  $nagios_check_freshness       = undef,
+  $nagios_servicegroups         = undef,
 ) inherits periodicnoise::defaults {
 }

--- a/spec/defines/monitored_cron_spec.rb
+++ b/spec/defines/monitored_cron_spec.rb
@@ -115,6 +115,19 @@ describe 'periodicnoise::monitored_cron', :type => :define do
       # actually can't test anything here
     end
   end
+  context 'with nagios_servicegroups set' do
+    let (:params) {{
+      :command                    => 'some_cron_command',
+      :hour                       => 0,
+      :minute                     => 0,
+      :nagios_servicegroups       => 'awesome_services',
+      :execution_timeout          => '6h'
+    }}
 
-
+    it 'should create a periodicnoise cron job with servicegroups set' do
+      should contain_periodicnoise__cron('some_monitored_cron')
+      # XXX cannot test exported resources (@@nagios_service) with rspec-puppet so we
+      # actually can't test anything here
+    end
+  end
 end


### PR DESCRIPTION
in order to let teams have specific aggregated views of their nagios checks
