### PR TITLE
Spike using nagios templates

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -14,7 +14,4 @@ class periodicnoise::defaults {
 
   $nagios_hostname              = $::fqdn
   $nagios_template              = 'generic-service'
-  $nagios_check_command         = "check_dummy!3!received no check results for a long time, please investigate"
-  $nagios_notification_interval = 24 * 60
-  $nagios_max_check_attempts    = 1
 }

--- a/manifests/monitored_cron.pp
+++ b/manifests/monitored_cron.pp
@@ -13,16 +13,12 @@ define periodicnoise::monitored_cron (
   $wrap_nagios_plugin           = undef,
   $nagios_notes_url             = undef,
   $nagios_freshness_threshold   = undef,
-  $nagios_check_freshness       = undef,
-  $nagios_check_command         = undef,
-  $nagios_max_check_attempts    = undef,
-  $nagios_contact_groups        = undef,
-  $nagios_servicegroups         = undef,
   $grace_time                   = undef,
   $monitor_ok                   = [],
   $monitor_warning              = [],
   $monitor_critical             = [],
   $monitor_unknown              = [],
+  $nagios_template              = undef,
 ) {
   $event = $name
 
@@ -51,19 +47,13 @@ define periodicnoise::monitored_cron (
 
   if ($ensure == 'present') {
     @@nagios_service { "$event on $periodicnoise::params::nagios_hostname":
-      host_name                   => $periodicnoise::params::nagios_hostname,
-      use                         => $periodicnoise::params::nagios_template,
-      check_command               => $nagios_check_command ? { undef   => $periodicnoise::params::nagios_check_command, default => $nagios_check_command },
-      check_interval              => $periodicnoise::params::nagios_check_interval,
-      notification_interval       => $notification_interval ? { undef => $periodicnoise::params::notification_interval, default => $notification_interval },
-      max_check_attempts          => $nagios_max_check_attempts ? { undef => $periodicnoise::params::nagios_max_check_attempts, default => $nagios_max_check_attempts },
-      contact_groups              => $nagios_contact_groups ? { undef => $periodicnoise::params::nagios_contact_groups, default => $nagios_contact_groups },
-      active_checks_enabled       => 0,
-      service_description         => $event,
-      notes_url                   => $nagios_notes_url ? { undef => $periodicnoise::params::nagios_notes_url, default => $nagios_notes_url },
-      check_freshness             => $nagios_check_freshness ? { undef => $periodicnoise::params::nagios_check_freshness, default => $nagios_check_freshness },
-      freshness_threshold         => $nagios_freshness_threshold ? { undef => $periodicnoise::params::nagios_freshness_threshold, default => $nagios_freshness_threshold },
-      servicegroups               => $nagios_servicegroups ? { undef => $periodicnoise::params::nagios_servicegroups, default => $nagios_servicegroups },
+      host_name             => $periodicnoise::params::nagios_hostname,
+      use                   => $nagios_template ? {  undef => $periodicnoise::params::nagios_template, default => $nagios_template },
+      notification_interval => $notification_interval,
+      active_checks_enabled => $periodicnoise::params::nagios_active_checks_enabled,
+      service_description   => $event,
+      notes_url             => $nagios_notes_url,
+      freshness_threshold   => $nagios_freshness_threshold,
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,14 +16,6 @@ class periodicnoise::params (
 
   $nagios_hostname              = $periodicnoise::defaults::nagios_hostname,
   $nagios_template              = $periodicnoise::defaults::nagios_template,
-  $nagios_check_command         = $periodicnoise::defaults::nagios_check_command,
-  $nagios_check_interval        = undef,
-  $nagios_notification_interval = $periodicnoise::defaults::nagios_notification_interval,
-  $nagios_max_check_attempts    = $periodicnoise::defaults::nagios_max_check_attempts,
-  $nagios_contact_groups        = undef,
-  $nagios_notes_url             = undef,
-  $nagios_freshness_threshold   = undef,
-  $nagios_check_freshness       = undef,
-  $nagios_servicegroups         = undef,
+  $nagios_active_checks_enabled = undef,
 ) inherits periodicnoise::defaults {
 }

--- a/spec/defines/monitored_cron_spec.rb
+++ b/spec/defines/monitored_cron_spec.rb
@@ -84,50 +84,16 @@ describe 'periodicnoise::monitored_cron', :type => :define do
     end
   end
 
-  context 'with a custom nagios check command' do
+  context 'with a nagios template set' do
     let (:params) {{
       :command           => 'some_cron_command',
       :hour              => 0,
       :minute            => 0,
       :execution_timeout => '10m',
-
-      # 2 is a nagios magic number exit code for CRITICAL
-      :nagios_check_command => 'check_dummy!2!received no check results for a long time, please investigate'
+      :nagios_template   => 'awesome-service',
     }}
-    it 'should create a periodicnoise cron job which raises a CRITICAL status in nagios' do
-      should contain_periodicnoise__cron('some_monitored_cron')
-      # XXX cannot test exported resources (@@nagios_service) with rspec-puppet so we
-      # actually can't test anything here
-    end
-  end
-  context 'with custom nagios_max_check_attempts set' do
-    let (:params) {{
-      :command                    => 'some_cron_command',
-      :hour                       => 0,
-      :minute                     => 0,
-      :nagios_max_check_attempts  => '3',
-      :execution_timeout          => '6h'
-    }}
-
     it 'should create a periodicnoise cron job' do
       should contain_periodicnoise__cron('some_monitored_cron')
-      # XXX cannot test exported resources (@@nagios_service) with rspec-puppet so we
-      # actually can't test anything here
-    end
-  end
-  context 'with nagios_servicegroups set' do
-    let (:params) {{
-      :command                    => 'some_cron_command',
-      :hour                       => 0,
-      :minute                     => 0,
-      :nagios_servicegroups       => 'awesome_services',
-      :execution_timeout          => '6h'
-    }}
-
-    it 'should create a periodicnoise cron job with servicegroups set' do
-      should contain_periodicnoise__cron('some_monitored_cron')
-      # XXX cannot test exported resources (@@nagios_service) with rspec-puppet so we
-      # actually can't test anything here
     end
   end
 end


### PR DESCRIPTION
In order to simplify the configuration of monitored_cron and even
increase the flexibility, pass in only nagios service templates.

Only timing and naming related parameters are kept, since those differ
per service.

Even active_checks_enabled can be solved via template now, in case you
still want to keep active service checks for a normally passivly
monitored service. This is useful while migrating from NRPE active checks to NCSA
based passive checks without monitoring state interruptions.

To keep existing behavior provide a nagios template for passive
services template on your nagios server like this

``` puppet
nagios_service { 'generic-passive-service':
    use => 'generic-service',
    active_checks_enabled => 0,
    max_check_attempts => 1,
    notification_interval => (24 * 60),
    check_command => "check_dummy!3!received no check results for a long time, please investigate",
    register => 0,
}
```

and use it as the default template like this:

``` puppet
class { 'puppet-periodicnoise::params':
    nagios_template => 'generic-passive-service',
}
```

@Bonko Please take a look.
