### PR TITLE
check parameters

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -24,6 +24,16 @@ define periodicnoise::cron (
 ) {
   include periodicnoise::params
 
+  if ($max_execution_start_delay != undef) and ("$max_execution_start_delay" =~ /^[0-9]+$/) {
+    fail("max_execution_start_delay is missing unit of measure like 3h4m5s for 3 hours, 4 minutes and 5 seconds")
+  }
+  if ($grace_time != undef) and ("$grace_time" =~ /^[0-9]+$/) {
+    fail("grace_time is missing unit of measure like 3h4m5s for 3 hours, 4 minutes and 5 seconds")
+  }
+  if ($execution_timeout != undef) and ("$execution_timeout" =~ /^[0-9]+$/) {
+    fail("execution_timeout is missing unit of measure like 3h4m5s for 3 hours, 4 minutes and 5 seconds")
+  }
+
   # Variables used in command.erb
   $_max_execution_start_delay = $max_execution_start_delay ? { undef => $periodicnoise::params::pn_max_execution_start_delay, default => $max_execution_start_delay }
   $_execution_timeout         = $execution_timeout

--- a/spec/defines/cron_spec.rb
+++ b/spec/defines/cron_spec.rb
@@ -227,4 +227,55 @@ describe 'periodicnoise::cron', :type => :define do
     end
 
   end
+
+  input_error_handling_cases = [
+    {
+      :params => {
+        :command => "some_command",
+      },
+      :expected_error_pattern => /Must pass execution_timeout/,
+    },
+    {
+      :params => {
+        :execution_timeout => '1s',
+      },
+      :expected_error_pattern => /Must pass command/,
+    },
+    {
+      :params => {
+        :command => 'some_command',
+        :execution_timeout => '2',
+      },
+      :expected_error_pattern => /execution_timeout is missing unit of measure like 3h4m5s for 3 hours, 4 minutes and 5 seconds/,
+    },
+    {
+      :params => {
+        :command => 'some_command',
+        :execution_timeout => '1s',
+        :max_execution_start_delay  => '2',
+      },
+      :expected_error_pattern => /max_execution_start_delay is missing unit of measure like 3h4m5s for 3 hours, 4 minutes and 5 seconds/,
+    },
+    {
+      :params => {
+        :command => 'some_command',
+        :execution_timeout => '1s',
+        :grace_time => '3',
+      },
+      :expected_error_pattern => /grace_time is missing unit of measure like 3h4m5s for 3 hours, 4 minutes and 5 seconds/,
+    },
+  ]
+
+  input_error_handling_cases.each do |error_case|
+
+    context "with handling of error #{error_case[:expected_error_pattern].to_s}" do
+
+      let (:params) { error_case[:params] }
+
+      it do
+        expect { catalogue }.to raise_error(Puppet::Error, error_case[:expected_error_pattern])
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
In order to catch calling errors in tests while developing instead of
once per week/month/year when the cron is actually executed, check time
arguments here.

Also provide tests for those checks.

@Bonko or @mlafeldt Please take a look. Some poor colleagues just ran into this kind of issue one or two weeks ago.
